### PR TITLE
Make include order follow Google/LLVM/Lakos guidelines

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,7 +7,7 @@
   BreakBeforeBraces: Attach
   ColumnLimit: '100'
   ConstructorInitializerAllOnOneLineOrOnePerLine: 'true'
-  IncludeBlocks: Regroup
+  IncludeBlocks: Preserve
   IndentPPDirectives: AfterHash
   IndentWidth: '2'
   NamespaceIndentation: All

--- a/source/greeter.cpp
+++ b/source/greeter.cpp
@@ -1,5 +1,6 @@
-#include <fmt/format.h>
 #include <greeter/greeter.h>
+
+#include <fmt/format.h>
 
 using namespace greeter;
 

--- a/test/source/greeter.cpp
+++ b/test/source/greeter.cpp
@@ -1,6 +1,7 @@
-#include <doctest/doctest.h>
 #include <greeter/greeter.h>
 #include <greeter/version.h>
+
+#include <doctest/doctest.h>
 
 #include <string>
 


### PR DESCRIPTION
@TheLartians Feel free to take this or leave it. LLVM, Google, and John Lakos recommend this order:
https://llvm.org/docs/CodingStandards.html#include-style
https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes

However, you may prefer to instead use "" instead of <>, as recommend by Cpp Core Guidelines:
https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#sf12-prefer-the-quoted-form-of-include-for-files-relative-to-the-including-file-and-the-angle-bracket-form-everywhere-else

If you use "" instead of <>, you could keep `IncludeBlocks: Regroup` but with the <> it seems clang-format wants to re-order.

Some places prefer/recommend <> exclusively, so YMMV. 