### PR TITLE
Add cross-platform builder in github action

### DIFF
--- a/.github/workflows/dockcross.yml
+++ b/.github/workflows/dockcross.yml
@@ -68,6 +68,8 @@ jobs:
         with:
           submodules: "recursive"
           fetch-depth: 0
+      - name: "Install dependency"
+        run: sudo apt-get update && sudo apt-get install -y ninja-build  
       - name: "Pull ${{ matrix.image_name }}..."
         run: docker pull dockcross/${{ matrix.image_name }}
       - name: "Make script"

--- a/.github/workflows/dockcross.yml
+++ b/.github/workflows/dockcross.yml
@@ -67,18 +67,16 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: "recursive"
-          fetch-depth: 0
-      - name: "Install dependency"
-        run: sudo apt-get update && sudo apt-get install -y ninja-build  
+          fetch-depth: 0 
       - name: "Pull ${{ matrix.image_name }}..."
         run: docker pull dockcross/${{ matrix.image_name }}
       - name: "Make script"
         run: docker run --rm dockcross/${{ matrix.image_name }} > ./dockcross-${{ matrix.image_name }}
       - name: "Config CMakefile"
-        run: cmake -B dockcross-${{ matrix.image_name }} -S . -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        run: ./dockcross-${{ matrix.image_name }} cmake -B dockcross-${{ matrix.image_name }} -S . -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
       - name: "Build"
-        run: ninja -C dockcross-${{ matrix.image_name }}
+        run: ./dockcross-${{ matrix.image_name }} ninja -C dockcross-${{ matrix.image_name }}
       - name: "Test"
         run: |
           cd dockcross-${{ matrix.image_name }}
-          ctest --build-config ${{ matrix.build_type }}
+          ./dockcross-${{ matrix.image_name }} ctest --build-config ${{ matrix.build_type }}

--- a/.github/workflows/dockcross.yml
+++ b/.github/workflows/dockcross.yml
@@ -71,7 +71,9 @@ jobs:
       - name: "Pull ${{ matrix.image_name }}..."
         run: docker pull dockcross/${{ matrix.image_name }}
       - name: "Make script"
-        run: docker run --rm dockcross/${{ matrix.image_name }} > ./dockcross-${{ matrix.image_name }}
+        run: |
+          docker run --rm dockcross/${{ matrix.image_name }} > ./dockcross-${{ matrix.image_name }}
+          chmod +x ./dockcross-${{ matrix.image_name }}
       - name: "Config CMakefile"
         run: ./dockcross-${{ matrix.image_name }} cmake -B dockcross-${{ matrix.image_name }} -S . -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
       - name: "Build"

--- a/.github/workflows/dockcross.yml
+++ b/.github/workflows/dockcross.yml
@@ -68,21 +68,5 @@ jobs:
         with:
           submodules: "recursive"
           fetch-depth: 0
-      - name: "Pull ${{ matrix.image_name }}..."
-        run: docker pull dockcross/${{ matrix.image_name }}
-      - name: "Make script"
-        run: |
-          docker run --rm dockcross/${{ matrix.image_name }} > ./dockcross-${{ matrix.image_name }}
-          chmod +x ./dockcross-${{ matrix.image_name }}
-      - name: "Make script"
-        run: |
-              ls
-              pwd
-      - name: "Config CMakefile"
-        run: ./dockcross-${{ matrix.image_name }} cmake -B dockcross-${{ matrix.image_name }} -S . -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-      - name: "Build"
-        run: ./dockcross-${{ matrix.image_name }} ninja -C dockcross-${{ matrix.image_name }}
-      - name: "Test"
-        run: |
-          cd dockcross-${{ matrix.image_name }}
-          ./dockcross-${{ matrix.image_name }} ctest --build-config ${{ matrix.build_type }}
+      - name: "build"
+        run: ./tools/dockcross-cmake-builder.sh ${{ matrix.image_name }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}

--- a/.github/workflows/dockcross.yml
+++ b/.github/workflows/dockcross.yml
@@ -74,6 +74,10 @@ jobs:
         run: |
           docker run --rm dockcross/${{ matrix.image_name }} > ./dockcross-${{ matrix.image_name }}
           chmod +x ./dockcross-${{ matrix.image_name }}
+      - name: "Make script"
+        run: |
+              ls
+              pwd
       - name: "Config CMakefile"
         run: ./dockcross-${{ matrix.image_name }} cmake -B dockcross-${{ matrix.image_name }} -S . -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
       - name: "Build"

--- a/.github/workflows/dockcross.yml
+++ b/.github/workflows/dockcross.yml
@@ -1,0 +1,82 @@
+name: Dockcross
+
+on:
+  push:
+    branches:
+      - "*"
+    paths-ignore:
+      - "**/README.md"
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  image:
+    name: "Build ${{ matrix.image_name }} ${{ matrix.build_type }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Remove images that you do not need
+        image_name:
+          [
+            android-arm,
+            android-arm64,
+            android-x86,
+            android-x86_64,
+            linux-x86,
+            linux-x64,
+            linux-x64-clang,
+            linux-arm64,
+            linux-arm64-musl,
+            linux-arm64-full,
+            linux-armv5,
+            linux-armv5-musl,
+            linux-m68k-uclibc,
+            linux-s390x,
+            linux-x64-tinycc,
+            linux-armv6,
+            linux-armv6-lts,
+            linux-armv6-musl,
+            linux-armv7l-musl,
+            linux-armv7,
+            linux-armv7a,
+            linux-x86_64-full,
+            linux-mips,
+            linux-ppc64le,
+            linux-riscv64,
+            linux-riscv32,
+            linux-xtensa-uclibc,
+            windows-static-x86,
+            windows-static-x64,
+            windows-static-x64-posix,
+            windows-armv7,
+            windows-shared-x86,
+            windows-shared-x64,
+            windows-shared-x64-posix,
+            windows-arm64,
+            manylinux2014-x64,
+            manylinux2014-x86,
+            manylinux2014-aarch64,
+            web-wasm,
+          ]
+        # Disable MinSizeRel RelWithDebInfo Debug Release
+        build_type: [Debug]
+    steps:
+      - name: "Checkout Code"
+        uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+          fetch-depth: 0
+      - name: "Pull ${{ matrix.image_name }}..."
+        run: docker pull dockcross/${{ matrix.image_name }}
+      - name: "Make script"
+        run: docker run --rm dockcross/${{ matrix.image_name }} > ./dockcross-${{ matrix.image_name }}
+      - name: "Config CMakefile"
+        run: cmake -B dockcross-${{ matrix.image_name }} -S . -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+      - name: "Build"
+        run: ninja -C dockcross-${{ matrix.image_name }}
+      - name: "Test"
+        run: |
+          cd dockcross-${{ matrix.image_name }}
+          ctest --build-config ${{ matrix.build_type }}

--- a/.github/workflows/dockcross.yml
+++ b/.github/workflows/dockcross.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: "recursive"
-          fetch-depth: 0 
+          fetch-depth: 0
       - name: "Pull ${{ matrix.image_name }}..."
         run: docker pull dockcross/${{ matrix.image_name }}
       - name: "Make script"

--- a/tools/dockcross-cmake-builder.sh
+++ b/tools/dockcross-cmake-builder.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+if (( $# >= 1 )); then
+    image=$1
+    build_file=build-${image%:*}
+    shift 1
+
+    cmake_arg=$@
+    echo "cmake arg: $cmake_arg"
+
+    #echo "Pulling dockcross/$image"
+    #docker pull dockcross/"$image"
+
+    echo "Make script dockcross-$image"
+    docker run --rm dockcross/"$image" > ./dockcross-"$image"
+    chmod +x ./dockcross-"$image"
+
+    echo "Build $build_file"
+    ./dockcross-"$image" cmake -B "$build_file" -S . -G Ninja $cmake_arg
+    ./dockcross-"$image" ninja -C "$build_file"
+else
+    echo "Usage: ${0##*/} <docker imag (ex: linux-x64/linux-x64-clang/linux-arm64/windows-shared-x64/windows-static-x64...)> <cmake arg.>"
+    exit 1
+fi


### PR DESCRIPTION
Cross-platform builder in github action:

- Dockcross :  https://github.com/dockcross/dockcross
- Support over 10 CPU architectures (x86, x86_64, ARMv5, ARMv6, ARMv7, ARMv8, RISCV32, RISCV64...)
- Support 4 compilers (Clang, GCC and TinyCC, Emscripten...)
- Support 3 OS (Linux, Android, Windows) and WebAssembly
- Add dockcross + CMake (and Ninja) scripts
- Complete support C++17 and partial C++20 (GCC 11 and LLVG/Clang 12)
- CMake 3.21
 