### PR TITLE
Changed 'No' to 'false' in .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,7 @@
   AccessModifierOffset: '-2'
   AlignTrailingComments: 'true'
   AllowAllParametersOfDeclarationOnNextLine: 'false'
-  AlwaysBreakTemplateDeclarations: 'No'
+  AlwaysBreakTemplateDeclarations: 'false'
   BreakBeforeBraces: Attach
   ColumnLimit: '100'
   ConstructorInitializerAllOnOneLineOrOnePerLine: 'true'


### PR DESCRIPTION
Having `'No'` inside `.clang-format` gives me the following error (Ubuntu 18.04):

```bash
YAML:6:36: error: invalid boolean
    AlwaysBreakTemplateDeclarations: 'No'
                                     ^~~~
  Error reading /home/my_path/ProjectName/.clang-format: Invalid argument
```

`'false'` fixes it.