### PR TITLE
Revert "Changed 'No' to 'false' in .clang-format"

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,7 @@
   AccessModifierOffset: '-2'
   AlignTrailingComments: 'true'
   AllowAllParametersOfDeclarationOnNextLine: 'false'
-  AlwaysBreakTemplateDeclarations: 'false'
+  AlwaysBreakTemplateDeclarations: 'No'
   BreakBeforeBraces: Attach
   ColumnLimit: '100'
   ConstructorInitializerAllOnOneLineOrOnePerLine: 'true'


### PR DESCRIPTION
Reverts TheLartians/ModernCppStarter#141, as `"No"` is indeed correct according to the [clang-format docs](https://clang.llvm.org/docs/ClangFormatStyleOptions.html).