### PR TITLE
copy paste .clang-tidy from a modern-cpp-template

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,6 @@
+---
+Checks: '*,-fuchsia-*,-google-*,-zircon-*,-abseil-*,-modernize-use-trailing-return-type,-llvm-*,-llvmlibc-*'
+CheckOptions: [{ key: misc-non-private-member-variables-in-classes, value: IgnoreClassesWithAllMemberVariablesBeingPublic }]
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+FormatStyle: none


### PR DESCRIPTION
It's a really good default.
It's copy-paste from https://github.com/filipdutescu/modern-cpp-template with one modification: turn off warnings as error for clang-tidy.