### PR TITLE
Docker and devcontainer files for development in an ubuntu container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+// .devcontainer/devcontainer.json
+{
+  "name": "ModernCppStarter",
+  "context": "..",
+  "dockerFile": "../Dockerfile",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "C_Cpp.default.compilerPath": "/usr/bin/clang++",
+        "cmake.generator": "Ninja"
+      },
+      "extensions": [
+        "ms-vscode.cmake-tools",
+        "ms-vscode.cpptools",
+        "twxs.cmake"
+      ]
+    }
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use official Ubuntu image
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Install dependencies
 RUN apt-get update && \
@@ -13,7 +13,7 @@ RUN apt-get update && \
     lldb \
     python3 \
     python3-pip \
-    python3-jinja2 \
+    python3-venv \
     clang \
     clang-tidy \
     lcov \
@@ -22,9 +22,20 @@ RUN apt-get update && \
     libpsl-dev \
     sudo \
     pkg-config \
+    ghostscript \
     && apt-get clean
 
-RUN pip3 install clang-format==14.0.6 cmake_format==0.6.11 pyyaml
+# Create and activate a virtual environment for Python tools
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Load shell.
+# Set CLANG_FORMAT_EXECUTABLE environment variable to use clang-format from the venv
+RUN ln -s /opt/venv/bin/clang-format /usr/local/bin/clang-format
+
+# Upgrade pip and install Python packages in venv
+RUN pip install --upgrade pip && \
+    pip install clang-format==14.0.6 cmake_format==0.6.11 pyyaml jinja2 pygments
+
+# Load shell
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Use official Ubuntu image
+FROM ubuntu:22.04
+
+# Install dependencies
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    build-essential \
+    cmake \
+    ninja-build \
+    git \
+    curl \
+    gdb \
+    lldb \
+    python3 \
+    python3-pip \
+    python3-jinja2 \
+    clang \
+    clang-tidy \
+    lcov \
+    doxygen \
+    meson \
+    libpsl-dev \
+    sudo \
+    pkg-config \
+    && apt-get clean
+
+RUN pip3 install clang-format==14.0.6 cmake_format==0.6.11 pyyaml
+
+# Load shell.
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ Additional arguments can be passed to the analyzers by setting the `CLANG_TIDY_A
 
 Ccache can be enabled by configuring with `-DUSE_CCACHE=<ON | OFF>`.
 
+#### Devcontainer
+
+The project includes a dockerfile along with a devcontainer file which allows for development in a docker container. Open the project folder in VS Code and you should be prompted to reopen the project in a container.
+
 ## FAQ
 
 > Can I use this for header-only libraries?


### PR DESCRIPTION
This includes a dockerfile along with a devcontainer file which allows for development in a docker container. Open the project folder in VS Code and you should be prompted to reopen the project in a container. 

Requested as a feature: https://github.com/TheLartians/ModernCppStarter/issues/200