### PR TITLE
Update doctest version to 2.4.12 to fix CI/CD errors with macOS builds

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,7 @@ include(../cmake/tools.cmake)
 
 include(../cmake/CPM.cmake)
 
-CPMAddPackage("gh:doctest/doctest@2.4.9")
+CPMAddPackage("gh:doctest/doctest@2.4.12")
 CPMAddPackage("gh:TheLartians/Format.cmake@1.7.3")
 
 if(TEST_INSTALLED_VERSION)


### PR DESCRIPTION
macOS builds are failing on the default template due to old `doctest` version:

```
Run cmake -Stest -Bbuild -DCMAKE_BUILD_TYPE=Debug
  cmake -Stest -Bbuild -DCMAKE_BUILD_TYPE=Debug
  shell: /bin/bash -e {0}
  env:
    CTEST_OUTPUT_ON_FAILURE: 1
    CPM_SOURCE_CACHE: /Users/runner/work/cppstarter/cppstarter/cpm_modules
-- The CXX compiler identification is AppleClang 17.0.0.17000013
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- CPM: Adding package doctest@2.4.9 (v2.4.9 to /Users/runner/work/cppstarter/cppstarter/cpm_modules/doctest/bbb3e61c4790cca23f5279ff9fddd6ec56ef3bd4)
CMake Error at /Users/runner/work/cppstarter/cppstarter/cpm_modules/doctest/bbb3e61c4790cca23f5279ff9fddd6ec56ef3bd4/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
Error: Process completed with exit code 1.
```

Updating `doctest` to `2.4.12` fixes the build.